### PR TITLE
Update Xplot GoogleChart formatters to recent library version

### DIFF
--- a/src/Html/XPlot.fs
+++ b/src/Html/XPlot.fs
@@ -66,7 +66,7 @@ let googleLoad = """<script type="text/javascript">
 fsi.AddHtmlPrinter(fun (chart:XPlot.GoogleCharts.GoogleChart) ->
   let ch = chart |> XPlot.GoogleCharts.Chart.WithSize (800, 450) |> applyTheme
   seq [ "script", googleJsapi; "script", googleLoad ], 
-  ch.InlineHtml)
+  ch.GetInlineHtml())
 
 
 // --------------------------------------------------------------------------------------

--- a/src/Text/FsLab.fs
+++ b/src/Text/FsLab.fs
@@ -13,7 +13,7 @@ let private displayHtml html =
 
 fsi.AddPrinter(fun (chart:XPlot.GoogleCharts.GoogleChart) ->
   let ch = chart |> XPlot.GoogleCharts.Chart.WithSize (800, 600)
-  ch.Html |> displayHtml
+  ch.GetHtml() |> displayHtml
   "(Google Chart)")
 
 fsi.AddPrinter(fun (chart:XPlot.Plotly.PlotlyChart) ->


### PR DESCRIPTION
XPlot version with corresponding changes: [1.4.2][XPlot_1.4.2]

Of course, PR can be merged after FsLab dependencies update. Seems like this was the only incompatibility with newest (at this moment) versions of used in FsLab libraries (the only that was noticed by type checker; haven't tested other libraries in runtime yet).

Update was needed because of XPlot new version API, which is described on XPlot (XPlot.Plotly, to be precise) homepage and not supported in current FsLab dependency ([1.3.1][XPlot_1.3.1]). So couldn't use a library according to provided documentation.

[XPlot_1.4.2]: https://github.com/TahaHachana/XPlot/releases/tag/1.4.2
[XPlot_1.3.1]: https://github.com/TahaHachana/XPlot/releases/tag/1.3.1